### PR TITLE
Harden weekly production export refresh

### DIFF
--- a/private_dot_hermes/scripts/private_executable_weekly_production_db_export.py
+++ b/private_dot_hermes/scripts/private_executable_weekly_production_db_export.py
@@ -3,9 +3,10 @@
 
 The script is designed for a weekly Hermes no-agent cron job. It keeps the
 current local snapshot until a complete replacement has downloaded with S3
-checksum validation and passed metadata plus object-for-object size checks,
-then swaps the directories on the same filesystem. Successful scheduled runs
-are silent; failures exit non-zero while preserving a validated snapshot.
+checksum validation and passed exact key grammar, metadata, size, and local
+SHA-256 manifest checks, then swaps the directories on the same filesystem.
+Successful scheduled runs are silent; failures exit non-zero while preserving
+a validated snapshot.
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ from __future__ import annotations
 import argparse
 import ctypes
 import fcntl
+import hashlib
 import json
 import os
 import re
@@ -466,18 +468,71 @@ def validate_completed_task(settings: Settings, task_id: str, task: dict) -> Non
         )
 
 
+def is_allowed_export_data_key(relative: str, export_only: tuple[str, ...]) -> bool:
+    parts = PurePosixPath(relative).parts
+    if len(parts) != 4:
+        return False
+    database, qualified_table, partition, filename = parts
+    if not partition.isdecimal():
+        return False
+    if filename != "_SUCCESS" and not (
+        filename.startswith("part-") and filename.endswith(".parquet")
+    ):
+        return False
+    for scope in export_only:
+        expected_database, schema = scope.split(".", maxsplit=1)
+        table_prefix = f"{schema}."
+        if database != expected_database or not qualified_table.startswith(
+            table_prefix
+        ):
+            continue
+        table = qualified_table.removeprefix(table_prefix)
+        return re.fullmatch(r"[A-Za-z_][A-Za-z0-9_$]*", table) is not None
+    return False
+
+
+def validate_inventory_names(
+    task_id: str,
+    names: set[str] | dict[str, int],
+    export_only: tuple[str, ...],
+) -> None:
+    expected_info = f"export_info_{task_id}.json"
+    table_info_prefix = f"export_tables_info_{task_id}_"
+    table_info_pattern = re.compile(
+        rf"{re.escape(table_info_prefix)}from_\d+_to_\d+\.json"
+    )
+    allowed_data_prefixes = tuple(
+        f"{scope.split('.', maxsplit=1)[0]}/{scope.split('.', maxsplit=1)[1]}."
+        for scope in export_only
+    )
+    for relative in names:
+        parts = PurePosixPath(relative).parts
+        if not relative or relative.startswith("/") or ".." in parts:
+            raise RuntimeError(f"unsafe export object key for {task_id}: {relative!r}")
+        is_table_metadata = table_info_pattern.fullmatch(relative) is not None
+        if relative.startswith(table_info_prefix) and not is_table_metadata:
+            raise RuntimeError(f"unexpected table metadata key: {relative}")
+        is_metadata = relative == expected_info or is_table_metadata
+        if not is_metadata and not relative.startswith(allowed_data_prefixes):
+            raise RuntimeError(
+                f"S3 object is outside requested export scopes: {relative}"
+            )
+        if not is_metadata and not is_allowed_export_data_key(relative, export_only):
+            raise RuntimeError(f"unexpected export data key: {relative}")
+    if expected_info not in names:
+        raise RuntimeError(f"RDS export {task_id} is missing {expected_info}")
+    if not any(table_info_pattern.fullmatch(name) is not None for name in names):
+        raise RuntimeError(f"RDS export {task_id} has no table metadata")
+    if not any(name.endswith(".parquet") for name in names):
+        raise RuntimeError(f"RDS export {task_id} has no Parquet files")
+
+
 def build_inventory(
     task_id: str,
     raw_objects: list[dict],
     export_only: tuple[str, ...],
 ) -> Inventory:
     prefix = f"{task_id}/"
-    expected_info = f"export_info_{task_id}.json"
-    table_info_prefix = f"export_tables_info_{task_id}_"
-    allowed_data_prefixes = tuple(
-        f"{scope.split('.', maxsplit=1)[0]}/{scope.split('.', maxsplit=1)[1]}."
-        for scope in export_only
-    )
     objects: dict[str, int] = {}
     for item in raw_objects:
         if not isinstance(item, dict):
@@ -489,16 +544,6 @@ def build_inventory(
         if not isinstance(key, str) or not key.startswith(prefix):
             raise RuntimeError(f"unexpected S3 object key for {task_id}: {key!r}")
         relative = key.removeprefix(prefix)
-        parts = PurePosixPath(relative).parts
-        if not relative or relative.startswith("/") or ".." in parts:
-            raise RuntimeError(f"unsafe S3 object key for {task_id}: {key!r}")
-        is_metadata = relative == expected_info or (
-            relative.startswith(table_info_prefix) and relative.endswith(".json")
-        )
-        if not is_metadata and not relative.startswith(allowed_data_prefixes):
-            raise RuntimeError(
-                f"S3 object is outside requested export scopes: {relative}"
-            )
         if not isinstance(size, int) or size < 0:
             raise RuntimeError(f"unexpected S3 object size for {key}: {size!r}")
         checksum_algorithms = item.get("ChecksumAlgorithm")
@@ -515,15 +560,7 @@ def build_inventory(
             raise RuntimeError(f"duplicate S3 object key for {task_id}: {relative}")
         objects[relative] = size
 
-    if expected_info not in objects:
-        raise RuntimeError(f"RDS export {task_id} is missing {expected_info}")
-    if not any(
-        name.startswith(table_info_prefix) and name.endswith(".json")
-        for name in objects
-    ):
-        raise RuntimeError(f"RDS export {task_id} has no table metadata")
-    if not any(name.endswith(".parquet") for name in objects):
-        raise RuntimeError(f"RDS export {task_id} has no Parquet files")
+    validate_inventory_names(task_id, objects, export_only)
     return Inventory(objects, len(objects), sum(objects.values()))
 
 
@@ -542,6 +579,58 @@ def local_inventory(directory: Path) -> dict[str, int]:
             relative = path.relative_to(directory).as_posix()
             result[relative] = path.stat().st_size
     return result
+
+
+def sha256_inventory(directory: Path, names: dict[str, int]) -> dict[str, str]:
+    checksums: dict[str, str] = {}
+    for relative in sorted(names):
+        digest = hashlib.sha256()
+        path = directory / relative
+        descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        with os.fdopen(descriptor, "rb") as stream:
+            while chunk := stream.read(8 * 1024 * 1024):
+                digest.update(chunk)
+        checksums[relative] = digest.hexdigest()
+    return checksums
+
+
+def validate_sha256_manifest(value: object, inventory: Inventory) -> dict[str, str]:
+    if not isinstance(value, dict) or set(value) != set(inventory.objects):
+        raise RuntimeError("missing or incomplete local SHA-256 manifest")
+    manifest: dict[str, str] = {}
+    for name, checksum in value.items():
+        if not isinstance(name, str) or not isinstance(checksum, str):
+            raise RuntimeError(  # noqa: TRY004 - malformed persisted manifest
+                "invalid local SHA-256 manifest"
+            )
+        if re.fullmatch(r"[0-9a-f]{64}", checksum) is None:
+            raise RuntimeError(f"invalid SHA-256 checksum for {name}")
+        manifest[name] = checksum
+    return manifest
+
+
+def discard_untrusted_reusable_files(
+    directory: Path,
+    local: dict[str, int],
+    inventory: Inventory,
+    expected_sha256: dict[str, str] | None,
+) -> dict[str, int]:
+    """Force transfer unless a same-size staging file matches trusted state."""
+    reusable = {
+        name: size
+        for name, size in local.items()
+        if inventory.objects.get(name) == size
+    }
+    if not reusable:
+        return local
+    discard = list(reusable)
+    if expected_sha256 is not None:
+        actual = sha256_inventory(directory, reusable)
+        discard = [name for name in reusable if actual[name] != expected_sha256[name]]
+    for name in discard:
+        (directory / name).unlink()
+        local.pop(name)
+    return local
 
 
 def validate_table_metadata(
@@ -601,6 +690,7 @@ def validate_download(
     task_id: str,
     inventory: Inventory,
     export_only: tuple[str, ...],
+    expected_sha256: dict[str, str] | None = None,
 ) -> None:
     if not directory.is_dir() or directory.is_symlink():
         raise RuntimeError(f"download directory is missing or unsafe: {directory}")
@@ -636,23 +726,48 @@ def validate_download(
         validate_table_metadata(directory, task_id, export_only)
     except RuntimeError as exc:
         raise PermanentExportError(str(exc)) from exc
+    if expected_sha256 is not None:
+        manifest = validate_sha256_manifest(expected_sha256, inventory)
+        actual = sha256_inventory(directory, inventory.objects)
+        mismatches = [
+            name for name in inventory.objects if actual[name] != manifest[name]
+        ]
+        if mismatches:
+            raise RuntimeError(
+                f"local SHA-256 mismatch for exported objects: {mismatches[:5]}"
+            )
 
 
-def ensure_download_space(
+def validate_installed_snapshot(
     settings: Settings,
-    inventory: Inventory,
-    existing: dict[str, int] | None = None,
-) -> None:
+    task_id: str,
+    manifest_value: object,
+) -> Inventory:
+    if not settings.target.is_dir() or settings.target.is_symlink():
+        raise RuntimeError(
+            f"download directory is missing or unsafe: {settings.target}"
+        )
+    local = local_inventory(settings.target)
+    validate_inventory_names(task_id, local, settings.export_only)
+    inventory = Inventory(local, len(local), sum(local.values()))
+    manifest = validate_sha256_manifest(manifest_value, inventory)
+    validate_download(
+        settings.target,
+        task_id,
+        inventory,
+        settings.export_only,
+        manifest,
+    )
+    return inventory
+
+
+def ensure_download_space(settings: Settings, inventory: Inventory) -> None:
     settings.target.parent.mkdir(parents=True, exist_ok=True)
     free = shutil.disk_usage(settings.target.parent).free
-    existing = existing or {}
-    reusable_bytes = sum(
-        size for name, size in existing.items() if inventory.objects.get(name) == size
-    )
-    required = (
-        max(inventory.total_bytes - reusable_bytes, 0)
-        + settings.free_space_headroom_bytes
-    )
+    # Checksum-aware sync may still redownload manifest-matching files based on
+    # timestamps and writes through temporary files. Reserve the complete export
+    # rather than crediting staging bytes that might coexist with a replacement.
+    required = inventory.total_bytes + settings.free_space_headroom_bytes
     if free < required:
         raise RuntimeError(
             f"not enough free disk for export: need {required / 1024**3:.2f} GiB, "
@@ -779,7 +894,14 @@ def finish_install(
     backup = settings.backup_path(task_id)
     staging = settings.staging_path(task_id)
     try:
-        validate_download(settings.target, task_id, inventory, settings.export_only)
+        expected_sha256 = validate_sha256_manifest(state.get("sha256"), inventory)
+        validate_download(
+            settings.target,
+            task_id,
+            inventory,
+            settings.export_only,
+            expected_sha256,
+        )
     except Exception:
         rollback_install(settings, task_id)
         raise
@@ -844,31 +966,28 @@ def refresh_once(
             shutil.rmtree(rejected_staging)
             fsync_directory(settings.target.parent)
 
-    if state.get("phase") == "installed" and not force:
+    if phase == "installed":
         installed_at = parse_timestamp(state.get("installed_at"))
-        if installed_at is not None and now - installed_at < settings.min_interval:
-            installed_task_id = str(state.get("task_id", ""))
-            backup = settings.backup_path(installed_task_id)
-            installed_task = aws.describe_export(installed_task_id)
-            if installed_task is None:
-                raise RuntimeError(
-                    f"installed RDS export task no longer exists: {installed_task_id}"
-                )
-            validate_completed_task(settings, installed_task_id, installed_task)
-            installed_inventory = build_inventory(
-                installed_task_id,
-                aws.list_export_objects(installed_task_id),
-                settings.export_only,
+        installed_task_id = str(state.get("task_id", ""))
+        backup = settings.backup_path(installed_task_id)
+        checksum_state = state.get("sha256")
+        if checksum_state is None:
+            raise RuntimeError(
+                "installed state does not have a trusted local SHA-256 manifest; "
+                "refusing to bless the current snapshot without a verified transfer"
             )
-            validate_download(
-                settings.target,
-                installed_task_id,
-                installed_inventory,
-                settings.export_only,
-            )
-            if backup.exists():
-                shutil.rmtree(backup)
-                fsync_directory(settings.target.parent)
+        # The committed local manifest is the proof for the installed snapshot.
+        # Do not couple local availability to RDS task history or S3 objects that
+        # may have been removed later by the independently managed lifecycle rule.
+        validate_installed_snapshot(settings, installed_task_id, checksum_state)
+        if backup.exists():
+            shutil.rmtree(backup)
+            fsync_directory(settings.target.parent)
+        if (
+            not force
+            and installed_at is not None
+            and now - installed_at < settings.min_interval
+        ):
             return RefreshResult(False, installed_task_id)
 
     task_id = str(state.get("task_id", "")) if phase in ACTIVE_PHASES else ""
@@ -932,19 +1051,39 @@ def refresh_once(
 
     try:
         validate_completed_task(settings, task_id, task)
-        state = updated_state(state, clock, phase="complete", status="COMPLETE")
+        # Preserve the transactional recovery checkpoint. Downgrading
+        # "installing" to "complete" here can strand a published target beside
+        # its backup if the process exits before finish_install records success.
+        completion_phase = "installing" if phase == "installing" else "complete"
+        state = updated_state(state, clock, phase=completion_phase, status="COMPLETE")
         save_state(settings.state_file, state)
         inventory = build_inventory(
             task_id, aws.list_export_objects(task_id), settings.export_only
         )
+    except AWSCommandError:
+        # AWS CLI failures are transient. Preserve the current checkpoint so a
+        # retry can resume the same task and, for installing, retain the old
+        # snapshot until publication has been durably validated.
+        raise
     except RuntimeError as exc:
-        save_rejected_state(settings, state, task_id, clock, exc)
+        # An installing checkpoint may be between atomic rename steps. Marking
+        # it rejected could make the rejected-state cleanup delete the only old
+        # snapshot still parked under the staging name.
+        if phase != "installing":
+            save_rejected_state(settings, state, task_id, clock, exc)
         raise
 
     # If a prior run crashed after the swap, finish cleanup instead of downloading again.
     if phase == "installing" and settings.target.exists():
         try:
-            validate_download(settings.target, task_id, inventory, settings.export_only)
+            expected_sha256 = validate_sha256_manifest(state.get("sha256"), inventory)
+            validate_download(
+                settings.target,
+                task_id,
+                inventory,
+                settings.export_only,
+                expected_sha256,
+            )
         except RuntimeError:
             recover_interrupted_install_paths(settings, task_id)
         else:
@@ -958,32 +1097,54 @@ def refresh_once(
             )
 
     staging = settings.staging_path(task_id)
-    staging_complete = False
     staging_inventory: dict[str, int] = {}
     if staging.exists():
         if not staging.is_dir() or staging.is_symlink():
             raise RuntimeError(f"refusing to use unsafe staging path: {staging}")
         # Reject nested symlinks before allowing AWS CLI to reuse the directory.
         staging_inventory = local_inventory(staging)
-        try:
-            validate_download(staging, task_id, inventory, settings.export_only)
-        except RuntimeError:
-            pass
-        else:
-            staging_complete = True
 
-    if not staging_complete:
-        ensure_download_space(settings, inventory, staging_inventory)
-        staging.mkdir(parents=True, exist_ok=True)
-        state = updated_state(state, clock, phase="downloading")
-        save_state(settings.state_file, state)
-        aws.sync_export(task_id, staging)
-        try:
-            validate_download(staging, task_id, inventory, settings.export_only)
-        except PermanentExportError as exc:
-            save_rejected_state(settings, state, task_id, clock, exc)
-            raise
-    state = updated_state(state, clock, phase="downloaded")
+    resume_sha256: dict[str, str] | None = None
+    if state.get("sha256") is not None:
+        resume_sha256 = validate_sha256_manifest(state.get("sha256"), inventory)
+    # AWS CLI can skip equal-size/equal-mtime files even in checksum mode. Only
+    # retain complete staging files when a trusted manifest proves their bytes.
+    staging_inventory = discard_untrusted_reusable_files(
+        staging,
+        staging_inventory,
+        inventory,
+        resume_sha256,
+    )
+
+    ensure_download_space(settings, inventory)
+    staging.mkdir(parents=True, exist_ok=True)
+    state = updated_state(state, clock, phase="downloading")
+    save_state(settings.state_file, state)
+    # Always invoke checksum-aware sync, even for a size-complete staging tree.
+    # A same-size corruption after an interrupted run must not bypass S3 checksums.
+    aws.sync_export(task_id, staging)
+    try:
+        validate_download(
+            staging,
+            task_id,
+            inventory,
+            settings.export_only,
+            resume_sha256,
+        )
+    except PermanentExportError as exc:
+        save_rejected_state(settings, state, task_id, clock, exc)
+        raise
+    downloaded_sha256 = (
+        resume_sha256
+        if resume_sha256 is not None
+        else sha256_inventory(staging, inventory.objects)
+    )
+    state = updated_state(
+        state,
+        clock,
+        phase="downloaded",
+        sha256=downloaded_sha256,
+    )
     save_state(settings.state_file, state)
 
     state = updated_state(state, clock, phase="installing")

--- a/tests/test_weekly_production_db_export.py
+++ b/tests/test_weekly_production_db_export.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import importlib.util
 import io
 import json
@@ -37,11 +38,15 @@ class FakeAWS:
         self.started = []
         self.synced = []
         self.known_tasks = set()
+        self.expired_object_tasks = set()
+        self.list_error: Exception | None = None
         self.warning_message: str | None = None
         self.table_status = "COMPLETE"
         self.omit_checksum = False
         self.extra_scope_object = False
         self.extra_table_target = False
+        self.nested_metadata_key = False
+        self.malformed_data_key = False
 
     def get_identity(self):
         return {
@@ -60,6 +65,10 @@ class FakeAWS:
         return self._task(task_id)
 
     def list_export_objects(self, task_id):
+        if self.list_error is not None:
+            raise self.list_error
+        if task_id in self.expired_object_tasks:
+            return []
         result = []
         for key, value in self._objects(task_id).items():
             item = {"Key": key, "Size": len(value)}
@@ -131,6 +140,12 @@ class FakeAWS:
             objects[prefix + "postgres/private.secret/1/part-00000.gz.parquet"] = (
                 b"PAR1secret"
             )
+        if self.nested_metadata_key:
+            objects[
+                prefix + f"export_tables_info_{task_id}_shadow/postgres/private.json"
+            ] = b"not parsed or scoped"
+        if self.malformed_data_key:
+            objects[prefix + "postgres/public.example/1/not-parquet.txt"] = b"invalid"
         return objects
 
 
@@ -157,6 +172,14 @@ class WeeklyProductionDBExportTests(unittest.TestCase):
             clock=lambda: self.now,
             sleeper=lambda _: None,
         )
+
+    @staticmethod
+    def checksum_manifest(aws, task_id):
+        prefix = f"{task_id}/"
+        return {
+            key.removeprefix(prefix): hashlib.sha256(value).hexdigest()
+            for key, value in aws._objects(task_id).items()
+        }
 
     def test_managed_cron_job_excludes_mutable_runtime_state(self):
         payload = json.loads(CRON_JOBS.read_text())
@@ -296,13 +319,98 @@ class WeeklyProductionDBExportTests(unittest.TestCase):
         result = self.run_refresh(aws)
 
         self.assertTrue(result.changed)
-        self.assertEqual(aws.synced, [])
+        self.assertEqual(aws.synced, [task_id])
         self.assertTrue((self.target / f"export_info_{task_id}.json").is_file())
         self.assertFalse(backup.exists())
         self.assertFalse(self.settings.staging_path(task_id).exists())
 
+    def test_installing_phase_survives_interruption_before_finish_install(self):
+        task_id = "transformity-production-no-audit-scraper-20260724-170000"
+        aws = FakeAWS(self.settings)
+        aws.known_tasks.add(task_id)
+        aws.sync_export(task_id, self.target)
+        aws.synced.clear()
+        exporter.save_state(
+            self.state_file,
+            {
+                "version": 1,
+                "phase": "installing",
+                "task_id": task_id,
+                "started_at": self.now.isoformat(),
+                "sha256": self.checksum_manifest(aws, task_id),
+            },
+        )
+        backup = self.settings.backup_path(task_id)
+        backup.mkdir()
+        (backup / "old.txt").write_text("old")
+
+        with (
+            mock.patch.object(
+                exporter,
+                "finish_install",
+                side_effect=OSError("simulated interruption before finish"),
+            ),
+            self.assertRaisesRegex(OSError, "simulated interruption before finish"),
+        ):
+            self.run_refresh(aws)
+
+        interrupted = json.loads(self.state_file.read_text())
+        self.assertEqual(interrupted["phase"], "installing")
+        self.assertTrue(backup.is_dir())
+
+        result = self.run_refresh(aws)
+
+        self.assertTrue(result.changed)
+        self.assertEqual(result.task_id, task_id)
+        self.assertFalse(backup.exists())
+        self.assertFalse(self.settings.staging_path(task_id).exists())
+        self.assertEqual(json.loads(self.state_file.read_text())["phase"], "installed")
+
+    def test_transient_inventory_error_preserves_installing_checkpoint(self):
+        task_id = "transformity-production-no-audit-scraper-20260724-170000"
+        aws = FakeAWS(self.settings)
+        aws.known_tasks.add(task_id)
+        aws.sync_export(task_id, self.target)
+        aws.synced.clear()
+        staging = self.settings.staging_path(task_id)
+        staging.mkdir()
+        (staging / "old.txt").write_text("old")
+        exporter.save_state(
+            self.state_file,
+            {
+                "version": 1,
+                "phase": "installing",
+                "task_id": task_id,
+                "started_at": self.now.isoformat(),
+                "sha256": self.checksum_manifest(aws, task_id),
+            },
+        )
+        aws.list_error = exporter.AWSCommandError("transient inventory failure")
+
+        with self.assertRaisesRegex(
+            exporter.AWSCommandError, "transient inventory failure"
+        ):
+            self.run_refresh(aws)
+
+        interrupted = json.loads(self.state_file.read_text())
+        self.assertEqual(interrupted["phase"], "installing")
+        self.assertEqual((staging / "old.txt").read_text(), "old")
+
+        aws.list_error = None
+        result = self.run_refresh(aws)
+
+        self.assertTrue(result.changed)
+        self.assertEqual(result.task_id, task_id)
+        self.assertEqual(aws.started, [])
+        self.assertFalse(staging.exists())
+        self.assertFalse(self.settings.backup_path(task_id).exists())
+        self.assertEqual(json.loads(self.state_file.read_text())["phase"], "installed")
+
     def test_recent_success_is_idempotent(self):
         task_id = "transformity-production-no-audit-scraper-20260723-180000"
+        aws = FakeAWS(self.settings)
+        aws.known_tasks.add(task_id)
+        aws.sync_export(task_id, self.target)
         exporter.save_state(
             self.state_file,
             {
@@ -310,11 +418,9 @@ class WeeklyProductionDBExportTests(unittest.TestCase):
                 "phase": "installed",
                 "task_id": task_id,
                 "installed_at": (self.now - timedelta(days=1)).isoformat(),
+                "sha256": self.checksum_manifest(aws, task_id),
             },
         )
-        aws = FakeAWS(self.settings)
-        aws.known_tasks.add(task_id)
-        aws.sync_export(task_id, self.target)
         aws.synced.clear()
 
         result = self.run_refresh(aws)
@@ -324,9 +430,17 @@ class WeeklyProductionDBExportTests(unittest.TestCase):
         self.assertEqual(aws.started, [])
         self.assertEqual(aws.synced, [])
         self.assertTrue((self.target / f"export_info_{task_id}.json").is_file())
+        state = json.loads(self.state_file.read_text())
+        self.assertEqual(
+            set(state["sha256"]),
+            {key.removeprefix(f"{task_id}/") for key in aws._objects(task_id)},
+        )
 
-    def test_recent_success_validates_target_even_without_a_cleanup_backup(self):
+    def test_installed_state_without_manifest_fails_closed(self):
         task_id = "transformity-production-no-audit-scraper-20260723-180000"
+        aws = FakeAWS(self.settings)
+        aws.known_tasks.add(task_id)
+        aws.sync_export(task_id, self.target)
         exporter.save_state(
             self.state_file,
             {
@@ -336,14 +450,64 @@ class WeeklyProductionDBExportTests(unittest.TestCase):
                 "installed_at": (self.now - timedelta(days=1)).isoformat(),
             },
         )
+        aws.synced.clear()
+
+        with self.assertRaisesRegex(RuntimeError, "trusted local SHA-256 manifest"):
+            self.run_refresh(aws)
+
+        state = json.loads(self.state_file.read_text())
+        self.assertNotIn("sha256", state)
+        self.assertEqual(aws.started, [])
+        self.assertEqual(aws.synced, [])
+
+    def test_recent_success_validates_target_even_without_a_cleanup_backup(self):
+        task_id = "transformity-production-no-audit-scraper-20260723-180000"
         aws = FakeAWS(self.settings)
         aws.known_tasks.add(task_id)
+        exporter.save_state(
+            self.state_file,
+            {
+                "version": 1,
+                "phase": "installed",
+                "task_id": task_id,
+                "installed_at": (self.now - timedelta(days=1)).isoformat(),
+                "sha256": self.checksum_manifest(aws, task_id),
+            },
+        )
 
         with self.assertRaisesRegex(RuntimeError, "download directory is missing"):
             self.run_refresh(aws)
 
         self.assertEqual(aws.started, [])
         self.assertEqual(aws.synced, [])
+
+    def test_recent_install_detects_same_size_local_corruption(self):
+        task_id = "transformity-production-no-audit-scraper-20260723-180000"
+        aws = FakeAWS(self.settings)
+        aws.known_tasks.add(task_id)
+        aws.sync_export(task_id, self.target)
+        prefix = f"{task_id}/"
+        checksums = {
+            key.removeprefix(prefix): hashlib.sha256(value).hexdigest()
+            for key, value in aws._objects(task_id).items()
+        }
+        exporter.save_state(
+            self.state_file,
+            {
+                "version": 1,
+                "phase": "installed",
+                "task_id": task_id,
+                "installed_at": (self.now - timedelta(days=1)).isoformat(),
+                "sha256": checksums,
+            },
+        )
+        parquet = next(self.target.rglob("*.parquet"))
+        parquet.write_bytes(b"BAD!test")
+
+        with self.assertRaisesRegex(RuntimeError, "SHA-256 mismatch"):
+            self.run_refresh(aws)
+
+        self.assertEqual(parquet.read_bytes(), b"BAD!test")
 
     def test_resumes_a_started_task_without_creating_a_duplicate(self):
         task_id = "transformity-production-no-audit-scraper-20260724-170000"
@@ -366,37 +530,7 @@ class WeeklyProductionDBExportTests(unittest.TestCase):
         self.assertEqual(aws.started, [])
         self.assertEqual(aws.synced, [task_id])
 
-    def test_reuses_a_complete_staging_download_without_requiring_free_space(self):
-        task_id = "transformity-production-no-audit-scraper-20260724-170000"
-        exporter.save_state(
-            self.state_file,
-            {
-                "version": 1,
-                "phase": "downloading",
-                "task_id": task_id,
-                "started_at": self.now.isoformat(),
-            },
-        )
-        self.target.mkdir()
-        (self.target / "current.txt").write_text("old")
-        aws = FakeAWS(self.settings, sync_error=RuntimeError("must not redownload"))
-        aws.known_tasks.add(task_id)
-        aws.sync_error = None
-        aws.sync_export(task_id, self.settings.staging_path(task_id))
-        aws.synced.clear()
-        aws.sync_error = RuntimeError("must not redownload")
-
-        with mock.patch.object(
-            exporter.shutil, "disk_usage", return_value=mock.Mock(free=0)
-        ):
-            result = self.run_refresh(aws)
-
-        self.assertTrue(result.changed)
-        self.assertEqual(aws.synced, [])
-        self.assertTrue((self.target / f"export_info_{task_id}.json").is_file())
-        self.assertFalse((self.target / "current.txt").exists())
-
-    def test_download_space_check_accounts_for_matching_partial_files(self):
+    def test_complete_staging_is_checksum_synced_before_install(self):
         task_id = "transformity-production-no-audit-scraper-20260724-170000"
         exporter.save_state(
             self.state_file,
@@ -411,9 +545,168 @@ class WeeklyProductionDBExportTests(unittest.TestCase):
         (self.target / "current.txt").write_text("old")
         aws = FakeAWS(self.settings)
         aws.known_tasks.add(task_id)
+        staging = self.settings.staging_path(task_id)
+        aws.sync_export(task_id, staging)
+        aws.synced.clear()
+        parquet = next(staging.rglob("*.parquet"))
+        parquet.write_bytes(b"BAD!test")
+
+        result = self.run_refresh(aws)
+
+        self.assertTrue(result.changed)
+        self.assertEqual(aws.synced, [task_id])
+        installed_parquet = next(self.target.rglob("*.parquet"))
+        self.assertEqual(installed_parquet.read_bytes(), b"PAR1test")
+        self.assertFalse((self.target / "current.txt").exists())
+
+    def test_resume_repairs_corruption_even_if_sync_skips_same_size_files(self):
+        task_id = "transformity-production-no-audit-scraper-20260724-170000"
+        self.target.mkdir()
+        (self.target / "current.txt").write_text("old")
+        aws = FakeAWS(self.settings)
+        aws.known_tasks.add(task_id)
+        staging = self.settings.staging_path(task_id)
+        aws.sync_export(task_id, staging)
+        aws.synced.clear()
+        exporter.save_state(
+            self.state_file,
+            {
+                "version": 1,
+                "phase": "downloaded",
+                "task_id": task_id,
+                "started_at": self.now.isoformat(),
+                "sha256": self.checksum_manifest(aws, task_id),
+            },
+        )
+        parquet = next(staging.rglob("*.parquet"))
+        parquet.write_bytes(b"BAD!test")
+
+        def skip_existing_same_size(task, destination):
+            aws.synced.append(task)
+            prefix = f"{task}/"
+            destination.mkdir(parents=True, exist_ok=True)
+            for key, value in aws._objects(task).items():
+                path = destination / key.removeprefix(prefix)
+                if path.is_file() and path.stat().st_size == len(value):
+                    continue
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(value)
+
+        with mock.patch.object(aws, "sync_export", side_effect=skip_existing_same_size):
+            result = self.run_refresh(aws)
+
+        self.assertTrue(result.changed)
+        self.assertEqual(aws.synced, [task_id])
+        installed_parquet = next(self.target.rglob("*.parquet"))
+        self.assertEqual(installed_parquet.read_bytes(), b"PAR1test")
+        self.assertFalse((self.target / "current.txt").exists())
+
+    def test_resume_rejects_wrong_bytes_written_after_manifest_precheck(self):
+        task_id = "transformity-production-no-audit-scraper-20260724-170000"
+        self.target.mkdir()
+        (self.target / "current.txt").write_text("old")
+        aws = FakeAWS(self.settings)
+        aws.known_tasks.add(task_id)
+        staging = self.settings.staging_path(task_id)
+        aws.sync_export(task_id, staging)
+        aws.synced.clear()
+        exporter.save_state(
+            self.state_file,
+            {
+                "version": 1,
+                "phase": "downloaded",
+                "task_id": task_id,
+                "started_at": self.now.isoformat(),
+                "sha256": self.checksum_manifest(aws, task_id),
+            },
+        )
+
+        def write_wrong_same_size_bytes(task, destination):
+            aws.synced.append(task)
+            prefix = f"{task}/"
+            for key, value in aws._objects(task).items():
+                path = destination / key.removeprefix(prefix)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"BAD!test" if key.endswith(".parquet") else value)
+
+        with (
+            mock.patch.object(
+                aws, "sync_export", side_effect=write_wrong_same_size_bytes
+            ),
+            mock.patch.object(exporter, "atomic_exchange") as exchange,
+            self.assertRaisesRegex(RuntimeError, "SHA-256 mismatch"),
+        ):
+            self.run_refresh(aws)
+
+        exchange.assert_not_called()
+        self.assertEqual((self.target / "current.txt").read_text(), "old")
+        self.assertEqual(next(staging.rglob("*.parquet")).read_bytes(), b"BAD!test")
+        self.assertEqual(
+            json.loads(self.state_file.read_text())["phase"], "downloading"
+        )
+
+    def test_resume_without_manifest_retransfers_complete_files(self):
+        task_id = "transformity-production-no-audit-scraper-20260724-170000"
+        self.target.mkdir()
+        (self.target / "current.txt").write_text("old")
+        aws = FakeAWS(self.settings)
+        aws.known_tasks.add(task_id)
+        staging = self.settings.staging_path(task_id)
+        aws.sync_export(task_id, staging)
+        aws.synced.clear()
+        exporter.save_state(
+            self.state_file,
+            {
+                "version": 1,
+                "phase": "downloading",
+                "task_id": task_id,
+                "started_at": self.now.isoformat(),
+            },
+        )
+        parquet = next(staging.rglob("*.parquet"))
+        parquet.write_bytes(b"BAD!test")
+
+        def skip_existing_same_size(task, destination):
+            aws.synced.append(task)
+            prefix = f"{task}/"
+            destination.mkdir(parents=True, exist_ok=True)
+            for key, value in aws._objects(task).items():
+                path = destination / key.removeprefix(prefix)
+                if path.is_file() and path.stat().st_size == len(value):
+                    continue
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(value)
+
+        with mock.patch.object(aws, "sync_export", side_effect=skip_existing_same_size):
+            result = self.run_refresh(aws)
+
+        self.assertTrue(result.changed)
+        self.assertEqual(aws.synced, [task_id])
+        installed_parquet = next(self.target.rglob("*.parquet"))
+        self.assertEqual(installed_parquet.read_bytes(), b"PAR1test")
+        self.assertFalse((self.target / "current.txt").exists())
+
+    def test_download_space_requires_full_incoming_capacity_with_reusable_files(
+        self,
+    ):
+        task_id = "transformity-production-no-audit-scraper-20260724-170000"
+        self.target.mkdir()
+        (self.target / "current.txt").write_text("old")
+        aws = FakeAWS(self.settings)
+        aws.known_tasks.add(task_id)
         objects = aws._objects(task_id)
         inventory = exporter.build_inventory(
             task_id, aws.list_export_objects(task_id), self.settings.export_only
+        )
+        exporter.save_state(
+            self.state_file,
+            {
+                "version": 1,
+                "phase": "downloading",
+                "task_id": task_id,
+                "started_at": self.now.isoformat(),
+                "sha256": self.checksum_manifest(aws, task_id),
+            },
         )
         prefix = f"{task_id}/"
         first_key, first_value = next(iter(objects.items()))
@@ -422,17 +715,19 @@ class WeeklyProductionDBExportTests(unittest.TestCase):
         partial.parent.mkdir(parents=True)
         partial.write_bytes(first_value)
         self.settings.free_space_headroom_bytes = 10
-        remaining_bytes = inventory.total_bytes - len(first_value)
+        insufficient_free = inventory.total_bytes + 9
 
-        with mock.patch.object(
-            exporter.shutil,
-            "disk_usage",
-            return_value=mock.Mock(free=remaining_bytes + 10),
+        with (
+            mock.patch.object(
+                exporter.shutil,
+                "disk_usage",
+                return_value=mock.Mock(free=insufficient_free),
+            ),
+            self.assertRaisesRegex(RuntimeError, "not enough free disk"),
         ):
-            result = self.run_refresh(aws)
+            self.run_refresh(aws)
 
-        self.assertTrue(result.changed)
-        self.assertEqual(aws.synced, [task_id])
+        self.assertEqual(aws.synced, [])
 
     def test_finishes_cleanup_after_a_crash_following_the_directory_swap(self):
         task_id = "transformity-production-no-audit-scraper-20260724-170000"
@@ -458,7 +753,7 @@ class WeeklyProductionDBExportTests(unittest.TestCase):
         self.assertTrue(result.changed)
         self.assertEqual(result.task_id, task_id)
         self.assertEqual(aws.started, [])
-        self.assertEqual(aws.synced, [])
+        self.assertEqual(aws.synced, [task_id])
         self.assertFalse(backup.exists())
         state = json.loads(self.state_file.read_text())
         self.assertEqual(state["phase"], "installed")
@@ -525,8 +820,69 @@ class WeeklyProductionDBExportTests(unittest.TestCase):
         self.assertEqual(aws.started, [expected_task])
         self.assertEqual(aws.synced, [expected_task])
 
+    def test_expired_install_cleans_old_backup_before_starting_next_export(self):
+        installed_task = "transformity-production-no-audit-scraper-20260717-180000"
+        aws = FakeAWS(self.settings)
+        aws.known_tasks.add(installed_task)
+        aws.sync_export(installed_task, self.target)
+        exporter.save_state(
+            self.state_file,
+            {
+                "version": 1,
+                "phase": "installed",
+                "task_id": installed_task,
+                "installed_at": (self.now - timedelta(days=7)).isoformat(),
+                "sha256": self.checksum_manifest(aws, installed_task),
+            },
+        )
+        aws.synced.clear()
+        backup = self.settings.backup_path(installed_task)
+        backup.mkdir()
+        (backup / "old.txt").write_text("old")
+
+        result = self.run_refresh(aws)
+
+        self.assertTrue(result.changed)
+        self.assertFalse(backup.exists())
+        self.assertEqual(
+            aws.started,
+            ["transformity-production-no-audit-scraper-20260724-180000"],
+        )
+
+    def test_expired_install_refreshes_after_source_objects_expire(self):
+        installed_task = "transformity-production-no-audit-scraper-20260617-180000"
+        aws = FakeAWS(self.settings)
+        aws.known_tasks.add(installed_task)
+        aws.sync_export(installed_task, self.target)
+        exporter.save_state(
+            self.state_file,
+            {
+                "version": 1,
+                "phase": "installed",
+                "task_id": installed_task,
+                "installed_at": (self.now - timedelta(days=37)).isoformat(),
+                "sha256": self.checksum_manifest(aws, installed_task),
+            },
+        )
+        aws.synced.clear()
+        aws.expired_object_tasks.add(installed_task)
+
+        result = self.run_refresh(aws)
+
+        self.assertTrue(result.changed)
+        self.assertEqual(
+            aws.started,
+            ["transformity-production-no-audit-scraper-20260724-180000"],
+        )
+        self.assertEqual(
+            json.loads(self.state_file.read_text())["task_id"], result.task_id
+        )
+
     def test_cleanup_retry_preserves_backup_when_installed_target_is_invalid(self):
         task_id = "transformity-production-no-audit-scraper-20260724-170000"
+        aws = FakeAWS(self.settings)
+        aws.known_tasks.add(task_id)
+        aws.sync_export(task_id, self.target)
         exporter.save_state(
             self.state_file,
             {
@@ -534,20 +890,16 @@ class WeeklyProductionDBExportTests(unittest.TestCase):
                 "phase": "installed",
                 "task_id": task_id,
                 "installed_at": (self.now - timedelta(days=1)).isoformat(),
+                "sha256": self.checksum_manifest(aws, task_id),
             },
         )
-        aws = FakeAWS(self.settings)
-        aws.known_tasks.add(task_id)
-        aws.sync_export(task_id, self.target)
         parquet = next(self.target.rglob("*.parquet"))
         parquet.unlink()
         backup = self.settings.backup_path(task_id)
         backup.mkdir()
         (backup / "old.txt").write_text("old")
 
-        with self.assertRaisesRegex(
-            RuntimeError, "download does not match S3 inventory"
-        ):
+        with self.assertRaisesRegex(RuntimeError, "has no Parquet files"):
             self.run_refresh(aws)
 
         self.assertTrue(backup.is_dir())
@@ -644,6 +996,30 @@ class WeeklyProductionDBExportTests(unittest.TestCase):
         aws.extra_scope_object = True
 
         with self.assertRaisesRegex(RuntimeError, "outside requested export scopes"):
+            self.run_refresh(aws)
+
+        self.assertEqual((self.target / "current.txt").read_text(), "keep")
+        self.assertEqual(aws.synced, [])
+
+    def test_nested_metadata_key_cannot_bypass_scope_validation(self):
+        self.target.mkdir()
+        (self.target / "current.txt").write_text("keep")
+        aws = FakeAWS(self.settings)
+        aws.nested_metadata_key = True
+
+        with self.assertRaisesRegex(RuntimeError, "unexpected table metadata key"):
+            self.run_refresh(aws)
+
+        self.assertEqual((self.target / "current.txt").read_text(), "keep")
+        self.assertEqual(aws.synced, [])
+
+    def test_malformed_data_key_is_rejected_before_download(self):
+        self.target.mkdir()
+        (self.target / "current.txt").write_text("keep")
+        aws = FakeAWS(self.settings)
+        aws.malformed_data_key = True
+
+        with self.assertRaisesRegex(RuntimeError, "unexpected export data key"):
             self.run_refresh(aws)
 
         self.assertEqual((self.target / "current.txt").read_text(), "keep")


### PR DESCRIPTION
## Summary

- make the installed snapshot self-verifying with a trusted local SHA-256 manifest, independent of later RDS/S3 retention
- preserve atomic-install recovery state across transient AWS failures; force retransfer when staging has no trusted manifest, and remove same-size corruption before trusted-manifest resume
- reject malformed export keys and fail closed rather than blessing legacy installed state without a trusted manifest
- reserve full incoming-export capacity plus headroom because checksum sync can rewrite trusted same-size files through temporary paths
- add adversarial coverage for crash checkpoints, lifecycle expiry, checksum resume, key grammar, disk limits, cleanup failures, and silent-success behavior

## Verification

- `python3 -m unittest -v tests/test_weekly_production_db_export.py` (40 tests)
- `PYTHONWARNINGS=error python3 -m unittest -q tests/test_weekly_production_db_export.py`
- `uvx ruff check private_dot_hermes/scripts/private_executable_weekly_production_db_export.py tests/test_weekly_production_db_export.py`
- `uvx ruff format --check private_dot_hermes/scripts/private_executable_weekly_production_db_export.py tests/test_weekly_production_db_export.py`
- `python3 -m py_compile ...`
- validated the managed script against the current 4,546-object, 13,469,376,352-byte local snapshot: exit 0, empty stdout/stderr in 67 seconds
- exercised `renameat2(RENAME_EXCHANGE)` on the `/root/dev` filesystem
- reproduced AWS CLI checksum-mode skipping equal-size/equal-mtime corruption and verified the forced-retransfer regression
